### PR TITLE
use root_path, instead of '/'

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
 
   def start
     return_to = params[:return_to] || root_path
-    redirect_to url_for("/auth/open_id?return_to=#{return_to}")
+    redirect_to url_for("#{root_path}auth/open_id?return_to=#{return_to}")
   end
 
   def failure

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
             <%= link_to 'Sign in', signin_path, :class => 'btn btn-small' %>
         <% end %>
       </div>
-      <a class="brand" href="/">Gistub</a>
+      <%= link_to 'Gistub', root_path, :class => 'brand' %>
 
       <div class="container nav-collapse">
         <ul class="nav">


### PR DESCRIPTION
I mounted a gistub app on non root path (e.g. /gistub/), but some "/" was hardcoded. replaced it by root_path.
