### PR TITLE
Making gistub work on Ruby 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '3.2.13'
 gem 'jquery-rails', '2.2.1'
 
 gem 'rails_autolink'
-gem 'redcarpet'
+gem 'kramdown'
 
 group :sqlite do
   gem 'sqlite3', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,10 @@ GEM
       activesupport (= 3.2.13)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
+    activerecord-jdbc-adapter (1.2.9)
+    activerecord-jdbcsqlite3-adapter (1.2.9)
+      activerecord-jdbc-adapter (~> 1.2.9)
+      jdbc-sqlite3 (~> 3.7.2)
     activeresource (3.2.13)
       activemodel (= 3.2.13)
       activesupport (= 3.2.13)
@@ -40,6 +44,9 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.2)
     builder (3.0.4)
+    childprocess (0.3.9)
+      ffi (~> 1.0, >= 1.0.11)
+    choice (0.1.6)
     commonjs (0.2.6)
     daemon_controller (1.1.4)
     daemons (1.1.9)
@@ -53,17 +60,21 @@ GEM
     factory_girl_rails (4.2.1)
       factory_girl (~> 4.2.0)
       railties (>= 3.0.0)
+    ffi (1.8.1-java)
     hashie (2.0.5)
     hike (1.2.3)
     i18n (0.6.1)
+    jdbc-sqlite3 (3.7.2.1)
     journey (1.0.4)
     jquery-rails (2.2.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.0)
+    json (1.8.0-java)
     kaminari (0.14.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    kramdown (1.0.2)
     less (2.3.2)
       commonjs (~> 0.2.6)
     less-rails (2.3.3)
@@ -74,6 +85,11 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.23)
+    mizuno (0.6.6)
+      childprocess (>= 0.2.6)
+      choice (>= 0.1.0)
+      ffi (>= 1.0.0)
+      rack (>= 1.0.0)
     multi_json (1.7.6)
     omniauth (1.1.4)
       hashie (>= 1.2, < 3)
@@ -116,7 +132,6 @@ GEM
     rake (10.0.4)
     rdoc (3.12.2)
       json (~> 1.4)
-    redcarpet (2.3.0)
     rspec-core (2.13.1)
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
@@ -147,6 +162,9 @@ GEM
     sqlite3 (1.3.7)
     therubyracer (0.10.2)
       libv8 (~> 3.3.10)
+    therubyrhino (2.0.2)
+      therubyrhino_jar (>= 1.7.3)
+    therubyrhino_jar (1.7.4)
     thin (1.5.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -162,6 +180,7 @@ GEM
       multi_json (~> 1.0, >= 1.0.2)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES
@@ -171,13 +190,13 @@ DEPENDENCIES
   factory_girl_rails (~> 4.0)
   jquery-rails (= 2.2.1)
   kaminari (= 0.14.1)
+  kramdown
   less-rails
   mizuno
   omniauth-openid (= 1.0.1)
   passenger
   rails (= 3.2.13)
   rails_autolink
-  redcarpet
   rspec-kickstarter
   rspec-rails (~> 2.0)
   simple_form (= 2.0.4)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,4 @@
-require 'redcarpet'
+require 'kramdown'
 
 module ApplicationHelper
 
@@ -40,8 +40,6 @@ module ApplicationHelper
   end
 
   def markdown(md_body)
-    renderer = Redcarpet::Render::HTML.new(:escape_html => true)
-    Redcarpet::Markdown.new(renderer).render(md_body)
+    Kramdown::Document.new(md_body).to_html
   end
-
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -64,21 +64,21 @@ Something!
 ## Bar
 
 - a
-- b 
+- b
 - c
 EOF
       result = markdown(md_body)
       expected = <<EOF
-<h1>foo</h1>
+<h1 id="foo">foo</h1>
 
 <p>Something!</p>
 
-<h2>Bar</h2>
+<h2 id="bar">Bar</h2>
 
 <ul>
-<li>a</li>
-<li>b </li>
-<li>c</li>
+  <li>a</li>
+  <li>b</li>
+  <li>c</li>
 </ul>
 EOF
       result.should eq(expected)


### PR DESCRIPTION
Due an old version of passenger, the bundle process would fail on ruby
2.0.0. Taking the opportunity to also update the remaining gems
