### PR TITLE
Prevented gist timestamp from overlapping with code box.

### DIFF
--- a/app/views/gists/_list.html.erb
+++ b/app/views/gists/_list.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% @gists.each do |gist| %>
     <% if gist.latest_history %>
-        <h4>
+        <h4 class="clearfix">
           <% if gist.is_public %>
             <i class="icon-pencil"></i>&nbsp;<%= link_to gist.title, gist %>
               <% if gist.favorites.present? %>

--- a/app/views/gists/_user_fav_page.html.erb
+++ b/app/views/gists/_user_fav_page.html.erb
@@ -5,7 +5,7 @@
   <% @favorites.each do |fav| %>
       <% gist = fav.gist %>
       <% if gist.present? %>
-          <h4>
+          <h4 class="clearfix">
           <%= link_to gist.title, gist %>
           <div class="pull-right">
             <small>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -9,7 +9,7 @@
       <hr/>
       <% @gists.each do |gist| %>
           <% if gist.latest_history.present? %>
-              <h4>
+              <h4 class="clearfix">
               <i class="icon-pencil"></i>&nbsp;<%= link_to gist.title, gist %>
                 <% if gist.favorites.present? %>
                     <small><%= gist.favorites.size %> <% if gist.favorites.size == 1 %>like<% else %>likes<% end %><% if gist.comments.present? %>,<% end %></small>


### PR DESCRIPTION
Looooooong gist title was making its timestamp to overlap with code box.

![Before](https://f.cloud.github.com/assets/498635/1848590/94ab77ba-7691-11e3-9cea-a774ef4dea08.png)

Fixed the issue applying clearfix to gist titles.

![After](https://f.cloud.github.com/assets/498635/1848603/28e5e398-7692-11e3-9fd5-7a0dc1a11759.png)
