### PR TITLE
Support markdown comments

### DIFF
--- a/app/views/comments/_list.html.erb
+++ b/app/views/comments/_list.html.erb
@@ -14,9 +14,9 @@
     </small>
     </span>
     <% if Gistub::Application.config.gistub_auto_link %>
-      <%= auto_link simple_format h comment.body %>
+      <%= auto_link raw markdown(comment.body) %>
     <% else %>
-      <%= simple_format h comment.body %>
+      <%= raw markdown(comment.body) %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
Parse and render comment bodies as markdown. 
Note that since markdown can include HTML, this does not affect the existing support for HTML tags in comments.

Tested with GISTUB_AUTO_LINK set to both true and false.
- GISTUB_AUTO_LINK == false
  - Normal URLs are NOT auto-linked, but Markdown-formatted links appear as links
- GISTUB_AUTO_LINK == true
  - Normal URLs ARE auto-linked, and Markdown-formatted links also appear as links

Screen shot (with GISTUB_AUTO_LINK == false):

![screen shot 2014-04-21 at 16 00 18](https://cloud.githubusercontent.com/assets/106760/2752910/6847bd5c-c923-11e3-9162-3d680a76bdc9.png)
