### PR TITLE
When MRI, change rendering engine of markdown (kramdown -> qiita-markdown)

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/rcaught/heroku-buildpack-cmake
+https://codon-buildpacks.s3.amazonaws.com/buildpacks/frederick/heroku-buildpack-ruby.tgz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm:
   - jruby-19mode
-  - 1.9.3
   - 2.1.5
   # TODO: tests on Ruby 2.2.0
   # - 2.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ source 'https://rubygems.org'
 gem 'rails', '4.0.13'
 gem 'jquery-rails'
 gem 'rails_autolink'
-gem 'kramdown'
+
+gem 'qiita-markdown', :platforms => :ruby
+gem 'kramdown',       :platforms => :jruby
 
 gem 'omniauth-openid'
 gem 'erubis'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     bullet (4.14.0)
       activesupport (>= 3.0.0)
       uniform_notifier (>= 1.6.0)
+    charlock_holmes (0.7.3)
     childprocess (0.5.5)
       ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
@@ -51,11 +52,13 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    crass (1.0.2)
     daemons (1.1.9)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
     erubis (2.7.0)
+    escape_utils (1.1.0)
     eventmachine (1.0.4)
     execjs (2.2.2)
     factory_girl (4.5.0)
@@ -64,8 +67,18 @@ GEM
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     ffi (1.9.6-java)
+    gemoji (2.1.0)
+    github-linguist (4.5.8)
+      charlock_holmes (~> 0.7.3)
+      escape_utils (~> 1.1.0)
+      mime-types (>= 1.19)
+      rugged (>= 0.23.0b)
+    greenmat (3.2.2.1)
     hashie (3.3.2)
     hike (1.2.3)
+    html-pipeline (1.11.0)
+      activesupport (>= 2)
+      nokogiri (~> 1.4)
     i18n (0.7.0)
     jdbc-sqlite3 (3.8.7)
     jquery-rails (3.1.2)
@@ -86,8 +99,10 @@ GEM
     magic_encoding (0.0.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    mem (0.1.5)
     method_source (0.8.2)
     mime-types (2.4.3)
+    mini_portile (0.6.2)
     minitest (4.7.5)
     mizuno (0.6.8)
       childprocess (>= 0.2.6)
@@ -96,6 +111,10 @@ GEM
       rack (>= 1.0.0)
     multi_json (1.10.1)
     netrc (0.10.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    nokogumbo (1.4.1)
+      nokogiri
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
@@ -103,6 +122,7 @@ GEM
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
     pg (0.18.2)
+    posix-spawn (0.3.11)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -114,6 +134,19 @@ GEM
       spoon (~> 0.0)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
+    pygments.rb (0.6.3)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.2.0)
+    qiita-markdown (0.8.0)
+      activesupport
+      gemoji
+      github-linguist
+      greenmat (>= 3.2.0.2, < 4)
+      html-pipeline
+      mem
+      pygments.rb
+      rugged (>= 0.21.1b2)
+      sanitize
     rack (1.5.2)
     rack-openid (1.3.1)
       rack (>= 1.1.0)
@@ -154,6 +187,11 @@ GEM
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
     ruby-openid (2.6.0)
+    rugged (0.23.0b4)
+    sanitize (4.0.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (= 1.4.1)
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -204,6 +242,7 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uniform_notifier (1.6.2)
+    yajl-ruby (1.2.1)
 
 PLATFORMS
   java
@@ -227,6 +266,7 @@ DEPENDENCIES
   omniauth-openid
   pg
   pry-rails
+  qiita-markdown
   rails (= 4.0.13)
   rails_autolink
   rspec-kickstarter

--- a/app.json
+++ b/app.json
@@ -6,6 +6,7 @@
     "postdeploy": "bundle exec rake db:create db:migrate"
   },
   "env": {
+    "BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-multi.git",
     "BUNDLE_WITHOUT": {
       "description": "bundle install --without <these>",
       "value": "test:development"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,9 @@
 # -*- encoding : utf-8 -*-
-require 'kramdown'
+begin
+  require 'kramdown'
+rescue LoadError
+end
+
 require 'digest/md5'
 require 'cgi'
 
@@ -47,11 +51,17 @@ module ApplicationHelper
   end
 
   def markdown(md_body)
-    begin
+    if defined?(Kramdown)
+      # JRuby
       Kramdown::Document.new(md_body).to_html
-    rescue Exception
-      md_body
+    else
+      # MRI
+      processor = Qiita::Markdown::Processor.new
+      result = processor.call(md_body)
+      result[:output].to_s.html_safe
     end
+  rescue Exception
+    md_body
   end
 
   def gravatar_image(user, options = {})


### PR DESCRIPTION
# Why?

[qiita-markdown](https://github.com/increments/qiita-markdown) is better than [kramdown](https://github.com/gettalong/kramdown) in markdown rendering
# Example
## Sample markdown
- https://gist.githubusercontent.com/sue445/a0d3f9e5177b2801fb41/raw/2e93016c2d74a8c99fdcbd0f4f607a1fe6446cf4/test.md
- https://gist.github.com/sue445/a0d3f9e5177b2801fb41
## Before (Use kramdown)

![gistub-before](https://cloud.githubusercontent.com/assets/608755/8635847/288fb182-2878-11e5-9fa1-648506ad4bc8.png)
## After (Use qiita-markdown)

![gistub-after](https://cloud.githubusercontent.com/assets/608755/8635849/2e7b1da2-2878-11e5-91c3-0f88d0a72069.png)
# Breaking changes
- If use qiita-markdown, requirements **ruby2.x+** :crying_cat_face: 
  - qiita-markdown support only ruby 2.x+
    - https://github.com/increments/qiita-markdown/blob/v0.8.0/qiita-markdown.gemspec#L19
  - jruby can not build [charlock_holmes](https://github.com/brianmario/charlock_holmes) (dependency of qiita-markdown)
